### PR TITLE
V0.0.4

### DIFF
--- a/lib/services/FileClerkService.js
+++ b/lib/services/FileClerkService.js
@@ -1,5 +1,5 @@
 const { collate } = require('./CollationService');
-const { isEmpty, isArray, compact } = require('../util/ArrayUtils');
+const { isEmpty, asArray, compact } = require('../util/ArrayUtils');
 const { format: dateStr } = require('../util/TimeUtils');
 
 exports.organize = async (sourcePath, targetPath, opts = {}) => {
@@ -25,7 +25,7 @@ exports.organizeByDate = (sourcePath, targetPath, opts = {}) => {
     dateProperty = 'ctime',
   } = opts;
 
-  const fmtStrArr = compact(isArray(dateFormat) ? dateFormat : [dateFormat]);
+  const fmtStrArr = compact(asArray(dateFormat));
 
   const collateFn = (f) => {
     const dateVal = f[dateProperty];

--- a/lib/util/ArrayUtils.js
+++ b/lib/util/ArrayUtils.js
@@ -6,8 +6,11 @@ const isArray = require('lodash.isarray');
 const compact = require('lodash.compact');
 const { mapSequence } = require('prolly');
 
+const asArray = maybeArr => (isArray(maybeArr) ? maybeArr : [maybeArr]);
+
 module.exports = {
   compact,
+  asArray,
   isArray,
   isEmpty,
   groupBy,

--- a/lib/util/ArrayUtils.js
+++ b/lib/util/ArrayUtils.js
@@ -2,10 +2,10 @@ const groupBy = require('lodash.groupby');
 const flatten = require('lodash.flatten');
 const orderBy = require('lodash.orderby');
 const isEmpty = require('lodash.isempty');
-const isArray = require('lodash.isarray');
 const compact = require('lodash.compact');
 const { mapSequence } = require('prolly');
 
+const { isArray } = Array;
 const asArray = maybeArr => (isArray(maybeArr) ? maybeArr : [maybeArr]);
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "lodash.compact": "^3.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.groupby": "^4.6.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.isempty": "^4.4.0",
     "lodash.orderby": "^4.6.0",
     "moment": "^2.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1587,10 +1587,6 @@ lodash.groupby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
 
-lodash.isarray@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
-
 lodash.isempty@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"


### PR DESCRIPTION
- No need for lodash.isarray. Use ES5's Array.isArray instead.